### PR TITLE
remove unnecessary environment variable

### DIFF
--- a/usr/share/gamescope-session-plus/sessions.d/playtron
+++ b/usr/share/gamescope-session-plus/sessions.d/playtron
@@ -25,6 +25,6 @@ post_client_shutdown() {
 	if [[ -e "$FACTORY_RESET_SENTINEL" ]]; then
 		OPTION=$(cat $FACTORY_RESET_SENTINEL)
 	        rm -f "$FACTORY_RESET_SENTINEL"
-		pkexec env WEBKIT_DISABLE_DMABUF_RENDERER=$WEBKIT_DISABLE_DMABUF_RENDERER playtron-factory-reset $OPTION
+		pkexec playtron-factory-reset $OPTION
 	fi
 }


### PR DESCRIPTION
The factory reset script does not use the webview.