### PR TITLE
ensure stress test files are removed

### DIFF
--- a/usr/share/gamescope-session-plus/sessions.d/playtron
+++ b/usr/share/gamescope-session-plus/sessions.d/playtron
@@ -13,6 +13,10 @@ PLAYTRON_GAMESCOPE_SESSION=1
 CLIENTCMD="grid"
 FACTORY_RESET_SENTINEL="/tmp/playtron-factory-reset-sentinel"
 
+# remove the potentially large disk stress test file
+# in case it was left behind by the stress test tool
+rm -f /var/home/playtron/stress-test-disk.dat
+
 if command -v /usr/libexec/playtron/dev-session-trigger > /dev/null; then
 	/usr/libexec/playtron/dev-session-trigger &
 fi


### PR DESCRIPTION
The stress test tool does its best to remove the file, however, there are situations where it could still remain.

This is a fallback to ensure that users are not affected by the file remaining when the device ships to them.