### PR TITLE
fix: use switcherooctl

### DIFF
--- a/usr/share/gamescope-session-plus/sessions.d/playtron
+++ b/usr/share/gamescope-session-plus/sessions.d/playtron
@@ -26,8 +26,10 @@ if lspci | grep -i vga | grep -i nvidia > /dev/null; then
 	# required for Nvidia GPUs to work with webview
 	# breaks webview for AMD and Intel GPUs
 	WEBKIT_DISABLE_DMABUF_RENDERER=1
+	GAMESCOPE_DISABLE_EXPLICIT_SYNC=1
 else
 	WEBKIT_DISABLE_DMABUF_RENDERER=0
+	GAMESCOPE_DISABLE_EXPLICIT_SYNC=0
 fi
 
 post_client_shutdown() {

--- a/usr/share/gamescope-session-plus/sessions.d/playtron
+++ b/usr/share/gamescope-session-plus/sessions.d/playtron
@@ -10,7 +10,7 @@ OAUTH_SERVER_TOKEN_URL="https://oauth2.playtron.red/oauth2/token"
 OAUTH_CLIENT_SERVER_PORT=1420
 OAUTH_GRANT_TYPE="authorization_code"
 PLAYTRON_GAMESCOPE_SESSION=1
-CLIENTCMD="grid"
+CLIENTCMD="switcherooctl launch grid"
 FACTORY_RESET_SENTINEL="/tmp/playtron-factory-reset-sentinel"
 
 # remove the potentially large disk stress test file


### PR DESCRIPTION
to use the dGPU on laptops that have two GPUs. This fixes graphical issues in account linking webviews and improves the performance in games.